### PR TITLE
Fix accepted populate for neurips 2024

### DIFF
--- a/neurips/neurips2024.typ
+++ b/neurips/neurips2024.typ
@@ -61,7 +61,7 @@
     keywords: keywords,
     date: date,
     abstract: abstract,
-    accepted: false,
+    accepted: accepted,
     aux: (get-notice: get-notice),
   )
   body


### PR DESCRIPTION
Issue: Accepted field will always be set to false regardless of user-defined value.
Fix: Populate the value to 2023 template.