### PR TITLE
fix: import error

### DIFF
--- a/neurips/main.typ
+++ b/neurips/main.typ
@@ -1,5 +1,5 @@
 #import "/neurips.typ": botrule, midrule, neurips2025, paragraph, toprule, url
-#import "/logo.typ": LaTeX, LaTeXe, TeX
+#import "./logo.typ": LaTeX, LaTeXe, TeX
 
 #let affls = (
   airi: ("AIRI", "Moscow", "Russia"),


### PR DESCRIPTION
Current version causes import error when the compiler is executed from another folder. The fix allows `main.typ` file to import logo, relative to its own path