### PR TITLE
fix: allow "Times New Roman" substitute font

### DIFF
--- a/neurips/neurips2023.typ
+++ b/neurips/neurips2023.typ
@@ -19,7 +19,7 @@
 )
 
 // We prefer to use Times New Roman when ever it is possible.
-#let font-family = ("Times New Roman", "Nimbus Roman", "TeX Gyre Termes")
+#let font-family = ("Times New Roman", "Liberation Serif", "Nimbus Roman", "TeX Gyre Termes")
 
 #let font = (
   Large: font-defaults.Large,


### PR DESCRIPTION
"Liberation Serif" is a layout compatible font from Liberation Fonts. This means that the characters of "Liberation Serif" are identical in width and height to the characters of "Times New Roman". This is helpful for people who don't use Windows, or don't have Times New Roman available on their system.

More information can be found here:
https://github.com/liberationfonts/liberation-fonts