### PR TITLE
feat: make equations more descriptive

### DIFF
--- a/neurips/neurips2023.typ
+++ b/neurips/neurips2023.typ
@@ -376,7 +376,7 @@
       )
       let color = rgb(0%, 8%, 45%)  // Originally `mydarkblue`. :D
       let content = link(el.location(), text(fill: color, numb))
-      [(#content)]
+      [Equation (#content)]
     } else {
       return it
     }


### PR DESCRIPTION
This kind of depends on the taste, and if I'm not wrong, NeurIPS has no rules about that.

In my opinion, this version is more explicit and clean.

`(3)` -> `Equation (3)`

Not really different from how we refer to figures.