### PR TITLE
Support footnote for authors in NeurIPS template

### DIFF
--- a/neurips/neurips2023.typ
+++ b/neurips/neurips2023.typ
@@ -121,6 +121,9 @@
   }
   let indices = affl.map(it => str(affl2idx.at(it))).join(" ")
   let result = strong(author.name)
+  if "footnote" in author {
+    result += footnote(author.footnote)
+  }
   if affilated {
     result += super(typographic: false, indices)
   }
@@ -423,6 +426,7 @@
     set text(size: font.normal)
     set par(leading: 4.5pt)
     set block(spacing: 1.0em)  // Original 11pt.
+    set footnote(numbering: "*")
     make-authors(authors, affls)
     v(0.3in - 0.1in)
   })


### PR DESCRIPTION
Issue: https://github.com/daskol/typst-templates/issues/58

Example:
```
#let authors = (
  (name: "Firstname1 Lastname1",
   affl: "skoltech",
   email: "author@example.org",
   footnote: [
    Use footnote for providing further information about author (webpage, 
    alternative address)---_not_ for acknowledging funding agencies.
   ],
   equal: true),
  (name: "Firstname2 Lastname2", affl: ("airi", "skoltech"), equal: true),
)
```